### PR TITLE
Bumped to syncthing relay version 1.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine AS builder
 LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
 
-ENV PKGVER 1.12.0
+ENV PKGVER 1.15.0
 
 # Busybox wget needs TLS support, curl is less painful to get working
 RUN apk add --no-cache ca-certificates curl && \


### PR DESCRIPTION
Increased version to 1.15.0 to match the newest version of https://github.com/syncthing/relaysrv/releases